### PR TITLE
DBRiderを活用してMapperTestに削除・更新・挿入メソッドの追加

### DIFF
--- a/src/main/java/com/example/roster10/StaffMapper.java
+++ b/src/main/java/com/example/roster10/StaffMapper.java
@@ -33,4 +33,6 @@ public interface StaffMapper {
 
     @Delete("DELETE FROM staff WHERE id = #{id}")
     void deleteById(Staff staff);
+
+    void deleteById(int i);
 }

--- a/src/main/java/com/example/roster10/StaffMapper.java
+++ b/src/main/java/com/example/roster10/StaffMapper.java
@@ -34,5 +34,4 @@ public interface StaffMapper {
     @Delete("DELETE FROM staff WHERE id = #{id}")
     void deleteById(Staff staff);
 
-    void deleteById(int i);
 }

--- a/src/test/java/com/example/roster10/StaffMapperTest.java
+++ b/src/test/java/com/example/roster10/StaffMapperTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -33,8 +32,7 @@ class StaffMapperTest {
     }
 
     @Test
-    @Sql("/sqlannotation/delete-staff.sql")
-    @DataSet(value = "datasets/staff.yml", cleanBefore = true)
+    @DataSet(value = "datasets/staff.yml", cleanBefore = true, executeScriptsBefore = "/sqlannotation/delete-staff.sql")
     @ExpectedDataSet("expected_datasets/after_insert.yml")
     @Transactional
     void ユーザーが挿入できること() {

--- a/src/test/java/com/example/roster10/StaffMapperTest.java
+++ b/src/test/java/com/example/roster10/StaffMapperTest.java
@@ -67,7 +67,9 @@ class StaffMapperTest {
     @ExpectedDataSet("expected_datasets/after_delete.yml")
     @Transactional
     void ユーザーが削除できること() {
-        staffMapper.deleteById(1);
+        Staff staffToDelete = new Staff(1, null, null, null);
+
+        staffMapper.deleteById(staffToDelete);
 
     }
 }

--- a/src/test/java/com/example/roster10/StaffMapperTest.java
+++ b/src/test/java/com/example/roster10/StaffMapperTest.java
@@ -26,7 +26,6 @@ class StaffMapperTest {
 
     @Test
     @DataSet(value = "datasets/staff.yml", cleanBefore = true)
-    @ExpectedDataSet("expected_datasets/after_find_all.yml")
     @Transactional
     void ユーザーが取得できること() {
         List<Staff> staffList = staffMapper.findAll();

--- a/src/test/java/com/example/roster10/StaffMapperTest.java
+++ b/src/test/java/com/example/roster10/StaffMapperTest.java
@@ -10,8 +10,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 @DBRider
@@ -43,4 +44,44 @@ class StaffMapperTest {
             assertEquals(expectedList.get(i).getNearestStation(), staffList.get(i).getNearestStation());
         }
     }
+
+    @Test
+    @DataSet(cleanBefore = false)
+    @Transactional
+    void ユーザーが挿入できること() {
+        Staff newStaff = new Staff(null, "Anna", LocalDate.of(2010, 1, 2), "Fukuoka");
+        staffMapper.insert(newStaff);
+
+        assertNotNull(newStaff.getId());
+
+        Optional<Staff> insertedStaff = staffMapper.findById(newStaff.getId());
+        assertTrue(insertedStaff.isPresent());
+        assertEquals("Anna", insertedStaff.get().getName());
+        assertEquals(LocalDate.of(2010, 1, 2), insertedStaff.get().getDateOfBirth());
+        assertEquals("Fukuoka", insertedStaff.get().getNearestStation());
+    }
+
+    @Test
+    @DataSet(value = "datasets/staff.yml", cleanBefore = true)
+    @Transactional
+    void ユーザーが更新できること() {
+        Staff updatedStaff = new Staff(1, "chika_updated", LocalDate.of(2000, 7, 1), "Tokyo_updated");
+        staffMapper.updateStaff(updatedStaff);
+
+        Optional<Staff> staff = staffMapper.findById(1);
+        assertTrue(staff.isPresent());
+        assertEquals("chika_updated", staff.get().getName());
+        assertEquals("Tokyo_updated", staff.get().getNearestStation());
+    }
+
+    @Test
+    @DataSet(value = {"datasets/staff.yml"}, cleanBefore = true)
+    @Transactional
+    void ユーザーが削除できること() {
+        staffMapper.deleteById(new Staff(1, null, null, null));
+
+        Optional<Staff> deletedStaff = staffMapper.findById(1);
+        assertFalse(deletedStaff.isPresent());
+    }
+
 }

--- a/src/test/java/com/example/roster10/StaffMapperTest.java
+++ b/src/test/java/com/example/roster10/StaffMapperTest.java
@@ -10,8 +10,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest(classes = StaffApplication.class)
@@ -29,7 +31,14 @@ class StaffMapperTest {
     void ユーザーが取得できること() {
         List<Staff> staffList = staffMapper.findAll();
 
+        List<Staff> expectedStaffList = Arrays.asList(
+                new Staff(1, "chika", LocalDate.of(2000, 7, 1), "Tokyo"),
+                new Staff(2, "airi", LocalDate.of(2005, 8, 13), "Meguro"),
+                new Staff(3, "nanami", LocalDate.of(1998, 10, 25), "Kichijoji")
+        );
+        assertEquals(expectedStaffList, staffList, "スタッフリストの内容が一致しません");
     }
+
 
     @Test
     @DataSet(value = "datasets/staff.yml", cleanBefore = true, executeScriptsBefore = "/sqlannotation/delete-staff.sql")

--- a/src/test/java/integrationtest/StaffControllerIntegrationTest.java
+++ b/src/test/java/integrationtest/StaffControllerIntegrationTest.java
@@ -20,7 +20,6 @@ import java.time.LocalDate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(classes = StaffApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-//@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DBRider
 public class StaffControllerIntegrationTest {
 

--- a/src/test/java/integrationtest/StaffControllerIntegrationTest.java
+++ b/src/test/java/integrationtest/StaffControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package integrationtest;
 
 import com.example.roster10.Staff;
+import com.example.roster10.StaffApplication;
 import com.example.roster10.StaffRequest;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
@@ -18,7 +19,8 @@ import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = StaffApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+//@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DBRider
 public class StaffControllerIntegrationTest {
 


### PR DESCRIPTION
**概要**
MapperTestに@DBRiderを活用し、削除・更新・挿入メソッドの追加をしました。

@DataSet(value = {"datasets/staff.yml"}, cleanBefore = true)　で、ymlファイルを使ったコードにしました。

- 動作確認 

<img width="897" alt="image" src="https://github.com/hiro903/Kadai10/assets/145466271/44538fe4-4859-41c5-9377-6821450ebfd5">

- コミットハッシュ
　320f9c2