### PR TITLE
Create gradle.yml

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,51 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Docker Compose Up For Database
+      run: docker-compose up -d
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
+    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
+    - name: Build with Gradle Wrapper
+      run: ./gradlew build
+
+    # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
+    # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.
+    #
+    # - name: Setup Gradle
+    #   uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+    #   with:
+    #     gradle-version: '8.5'
+    #
+    # - name: Build with Gradle 8.5
+    #   run: gradle build
+

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,8 +34,8 @@ jobs:
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
-      with:
-      　gradle-version: '8.5'
+    - name: Add Execute Permission for Gradle Wrapper
+      run: chmod +x gradlew
            
     - name: Build with Gradle Wrapper
       run: ./gradlew build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,7 +34,9 @@ jobs:
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
-
+      with:
+      　gradle-version: '8.5'
+           
     - name: Build with Gradle Wrapper
       run: ./gradlew build
 


### PR DESCRIPTION
**概要**
Ciの実装

- `Docker Compose Up For Database`　データベースをバックグラウンドで起動します
- `Set up JDK 17`　JDK 17をセットアップ
- `Build with Gradle Wrapper`　Gradle Wrapperを使用してプロジェクトをビルドし依存関係のダウンロードとビルドが行われ、ビルド結果が生成されます

**つまづいたところ**
dependency-submission を消してJob一つにして動かしてみたら
「build
Process completed with exit code 126.」とでたので、Gradleに実行権限がなくエラーになっていると調べ
「- name: Add Execute Permission for Gradle Wrapper
      run: chmod +x gradlew」を追加してCIが通りました